### PR TITLE
fix: align status labels with review feedback

### DIFF
--- a/sord-field-kit/src/App.tsx
+++ b/sord-field-kit/src/App.tsx
@@ -362,7 +362,7 @@ export default function App() {
       case "locating":
         return "GPS locating…";
       case "error":
-        return gpsError ? `GPS error` : "GPS error";
+        return gpsError ? `GPS error: ${gpsError}` : "GPS error";
       default:
         return "GPS idle";
     }
@@ -455,7 +455,7 @@ export default function App() {
           onPause: offline.pauseCaching,
           onResume: offline.resumeCaching,
           onClear: offline.clearCache,
-          activeUrl: pmtilesFetchUrl ?? undefined,
+          activeUrl: offline.activeUrl ?? undefined,
         }}
         mediapipe={{
           enabled: mediapipeEnabled,

--- a/sord-field-kit/src/components/SettingsPanel.tsx
+++ b/sord-field-kit/src/components/SettingsPanel.tsx
@@ -46,9 +46,9 @@ function formatOfflineStatus(status: OfflineStatus, progress: number) {
     case "downloading":
       return `Caching tiles… ${progress}% (${status.storedChunks}/${status.totalChunks || "?"})`;
     case "ready":
-      return `Cache ready (${status.totalChunks || status.storedChunks} segments)`;
+      return `Cache ready (${status.storedChunks}/${status.totalChunks || status.storedChunks} segments)`;
     case "paused":
-      return `Paused at ${progress}%`;
+      return `Paused at ${progress}% (${status.storedChunks}/${status.totalChunks || "?"})`;
     case "error":
       return status.error ? `Error: ${status.error}` : "Cache error";
     default:


### PR DESCRIPTION
## Summary
- include the GPS error message in the status pill when a fix fails
- feed the offline hook's active source URL into the settings panel and surface chunk ratios for paused/ready states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c88a3982208328a205a55316a93cab