### PR TITLE
Preserve offline PMTiles source when caching basemaps

### DIFF
--- a/sord-field-kit/src/App.tsx
+++ b/sord-field-kit/src/App.tsx
@@ -82,6 +82,9 @@ export default function App() {
   const pmtilesFetchUrl = useMemo(() => {
     if (!basemapInfo) return null;
     if (basemapInfo.usedOfflineCache) {
+      if (!basemapInfo.sourceUrl.startsWith("indexeddb://")) {
+        return basemapInfo.sourceUrl;
+      }
       return basemapInfo.usedLocal ? LOCAL_PM_TILES_PATH : REMOTE_PM_TILES_URL;
     }
     return basemapInfo.sourceUrl;
@@ -428,6 +431,7 @@ export default function App() {
           waypoints={waypoints}
           visibleLayers={layerVisibility}
           offlineBlob={offline.offlineBlob}
+          offlineSourceUrl={offline.cachedSourceUrl}
           onMapReady={(map, info) => {
             mapInstanceRef.current = map;
             setBasemapInfo(info);
@@ -455,7 +459,8 @@ export default function App() {
           onPause: offline.pauseCaching,
           onResume: offline.resumeCaching,
           onClear: offline.clearCache,
-          activeUrl: offline.activeUrl ?? undefined,
+          activeUrl:
+            offline.cachedSourceUrl ?? pmtilesFetchUrl ?? undefined,
         }}
         mediapipe={{
           enabled: mediapipeEnabled,

--- a/sord-field-kit/src/hooks/useOffline.ts
+++ b/sord-field-kit/src/hooks/useOffline.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { clearPMTilesBlob, readPMTilesBlob, savePMTilesBlob, readSetting, writeSetting } from "../lib/storage";
+import {
+  clearPMTilesBlob,
+  readPMTilesBlob,
+  savePMTilesBlob,
+  readSetting,
+  writeSetting,
+} from "../lib/storage";
 
 export type OfflinePhase = "idle" | "downloading" | "paused" | "ready" | "error";
 
@@ -18,6 +24,7 @@ const CHUNK_SIZE = 64 * 1024;
 export function useOffline(pmtilesUrl: string | null) {
   const [enabled, setEnabled] = useState(() => readSetting(PREF_KEY, false));
   const [offlineBlob, setOfflineBlob] = useState<Blob | null>(null);
+  const [cachedSourceUrl, setCachedSourceUrl] = useState<string | null>(null);
   const [hasCache, setHasCache] = useState(false);
   const [status, setStatus] = useState<OfflineStatus>({
     phase: "idle",
@@ -32,9 +39,11 @@ export function useOffline(pmtilesUrl: string | null) {
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const blob = await readPMTilesBlob();
+      const record = await readPMTilesBlob();
+      const blob = record?.blob ?? null;
       if (!cancelled) {
         setOfflineBlob(blob);
+        setCachedSourceUrl(record?.sourceUrl ?? null);
         setHasCache(Boolean(blob));
         if (blob) {
           const chunkEstimate = Math.max(1, Math.ceil(blob.size / CHUNK_SIZE));
@@ -84,6 +93,7 @@ export function useOffline(pmtilesUrl: string | null) {
     const controller = new AbortController();
     controllerRef.current = controller;
     activeUrlRef.current = pmtilesUrl;
+    setCachedSourceUrl(pmtilesUrl);
     setStatus({
       phase: "downloading",
       storedChunks: 0,
@@ -125,9 +135,10 @@ export function useOffline(pmtilesUrl: string | null) {
         offset += chunk.length;
       }
       const blob = new Blob([buffer], { type: "application/octet-stream" });
-      await savePMTilesBlob(blob);
+      await savePMTilesBlob(blob, pmtilesUrl);
       setOfflineBlob(blob);
       setHasCache(true);
+      setCachedSourceUrl(pmtilesUrl);
       const finalChunks = estimatedChunks || storedChunks || 1;
       setStatus({
         phase: "ready",
@@ -171,6 +182,7 @@ export function useOffline(pmtilesUrl: string | null) {
     resetController();
     await clearPMTilesBlob();
     setOfflineBlob(null);
+    setCachedSourceUrl(null);
     setHasCache(false);
     setStatus({
       phase: "idle",
@@ -213,5 +225,6 @@ export function useOffline(pmtilesUrl: string | null) {
     resumeCaching,
     clearCache,
     activeUrl: activeUrlRef.current,
+    cachedSourceUrl,
   };
 }


### PR DESCRIPTION
## Summary
- extend the offline caching hook to remember the original PMTiles source and expose it to the UI
- persist the cached source URL in IndexedDB and reuse it when resolving PMTiles blobs
- thread the cached source through MapView and Settings so offline tiles reload with the right attribution

## Testing
- `cd sord-field-kit && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c893b3951c83288ec5669414ef41c6